### PR TITLE
Fix useMatomo() return when plugin is not installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { inject, ref, type App, type InjectionKey, type Ref } from 'vue';
+import { inject, ref, toRef, type App, type InjectionKey, type Ref } from 'vue';
 import type { RouteLocationNormalized } from 'vue-router';
 import type { MatomoOptions, MatomoInstance, SiteSearchReturn } from '@/types';
 import { defaultOptions, isClient, getMatomo, getResolvedHref, loadScript, matomoEvents } from '@/utils';
@@ -194,8 +194,8 @@ export function createVueMatomo(options: MatomoOptions) {
 
 export function useMatomo(): Ref<MatomoInstance | undefined> {
   if (!isClient()) return ref();
-  const matomo = inject(matomoKey);
-  return matomo as Ref<MatomoInstance | undefined>; // Assert it’s always provided
+  const matomo = toRef(inject(matomoKey));
+  return matomo;
 }
 
 export const matomoKey: InjectionKey<Ref<MatomoInstance | undefined>> = Symbol('Matomo');


### PR DESCRIPTION
Instead of asserting that the value isn't `undefined`, we can just ensure it isn't. With `toRef`, the returned value is consistently `Ref<MatomoInstance | undefined>`.

This way, an app can install the plugin conditionally (as suggested in https://github.com/AmazingDreams/vue-matomo/issues/81) and do `matomo.value` without risking an error.