### PR TITLE
Inject with undefined default to suppress warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ export function createVueMatomo(options: MatomoOptions) {
 
 export function useMatomo(): Ref<MatomoInstance | undefined> {
   if (!isClient()) return ref();
-  return toRef(inject(matomoKey));
+  return toRef(inject(matomoKey, undefined));
 }
 
 export const matomoKey: InjectionKey<Ref<MatomoInstance | undefined>> = Symbol('Matomo');


### PR DESCRIPTION
I meant to include this in #13 , sorry for forgetting about it. This suppresses the Vue warning `injection "Symbol(Matomo)" not found` when using without the plugin installed.