### PR TITLE
Make vue-router peer dep optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
     "vue": "^3.0.0",
     "vue-router": ">=4.0.0"
   },
+  "peerDependenciesMeta": {
+    "vue-router": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^24.10.9",
     "@vitejs/plugin-vue": "^6.0.3",


### PR DESCRIPTION
For usage in a project that doesn't use vue-router. Uses [peerDependenciesMeta](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta).

I don't know how to test this. I tried using `https://github.com/arildm/vue3-matomo#vue-router-optional` as dependency identifier, but that broke typechecking.